### PR TITLE
Provide multiline string example as pep8 docstring

### DIFF
--- a/_episodes/07-style.md
+++ b/_episodes/07-style.md
@@ -69,10 +69,13 @@ average(values)
 > and end with three matching characters.
 >
 > ~~~
-> """This string spans
-> multiple lines.
+> """This string spans multiple lines.
 >
-> Blank lines are allowed."""
+> Blank lines are allowed. For documentation, typically a first line
+> summarizes the functionality, and a blank line separates that summary
+> from the remainder. The ending three quote characters, in the case of a
+> long documentation string, are typically on their own line.
+> """
 > ~~~
 > {: .python}
 {: .callout}


### PR DESCRIPTION
Given that it's an episode on style, we might as well provide a multiline string in the callout that looks like a PEP8-compliant multiline docstring.
